### PR TITLE
Implemented the in-memory MQ broker and added Track GET and POST requ…

### DIFF
--- a/ch09/todo-jms/pom.xml
+++ b/ch09/todo-jms/pom.xml
@@ -38,11 +38,10 @@
 <!--        Para solucionar el error, agrega la siguiente dependencia en tu pom.xml para incluir el broker embebido:-->
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-broker</artifactId>
-            <version>5.18.2</version>
+            <artifactId>artemis-jakarta-server</artifactId>
+             <version>2.31.2</version>
         </dependency>
-
-<!--    TODO    error ClassNotFoundException: org.apache.activemq.store.kahadb.KahaDBPersistenceAdapter indica que falta la clase de persistencia KahaDB en el classpath. Esto ocurre porque la dependencia necesaria no está incluida en tu proyecto.-->
+ <!--    TODO    error ClassNotFoundException: org.apache.activemq.store.kahadb.KahaDBPersistenceAdapter indica que falta la clase de persistencia KahaDB en el classpath. Esto ocurre porque la dependencia necesaria no está incluida en tu proyecto.-->
 
         <dependency>
             <groupId>org.apache.activemq</groupId>
@@ -99,6 +98,14 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
     </dependencies>
 
     <build>

--- a/ch09/todo-jms/src/main/java/com/apress/todo/config/ActiveMQBrokerConfig.java
+++ b/ch09/todo-jms/src/main/java/com/apress/todo/config/ActiveMQBrokerConfig.java
@@ -1,0 +1,22 @@
+package com.apress.todo.config;
+
+
+import org.apache.activemq.broker.BrokerService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ActiveMQBrokerConfig {
+
+    @Bean
+    public BrokerService broker() throws Exception {
+        BrokerService broker = new BrokerService();
+        broker.setBrokerName("inMemoryBroker-broker");
+        broker.setPersistent(false); // In-memory broker
+        broker.setUseJmx(true);      // Enable JMX for monitoring
+        broker.addConnector("vm://localhost");
+        broker.start();
+        return broker;
+    }
+}
+

--- a/ch09/todo-jms/src/main/java/com/apress/todo/config/ToDoConfig.java
+++ b/ch09/todo-jms/src/main/java/com/apress/todo/config/ToDoConfig.java
@@ -1,5 +1,6 @@
 package com.apress.todo.config;
 
+import org.apache.activemq.ActiveMQConnectionFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jms.DefaultJmsListenerContainerFactoryConfigurer;
 import org.springframework.context.annotation.Bean;
@@ -8,6 +9,7 @@ import org.springframework.jms.annotation.JmsListenerConfigurer;
 import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
 import org.springframework.jms.config.JmsListenerContainerFactory;
 import org.springframework.jms.config.JmsListenerEndpointRegistrar;
+import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.support.converter.MappingJackson2MessageConverter;
 import org.springframework.jms.support.converter.MessageType;
 import org.springframework.jms.support.converter.MessageConverter;
@@ -29,6 +31,13 @@ public class ToDoConfig {
         
     }
     
+    @Bean
+    public JmsTemplate jmsTemplate(ConnectionFactory jmsConnectionFactory,MessageConverter jacksonJmsMessageConverter) {
+    	JmsTemplate template = new JmsTemplate(jmsConnectionFactory);
+        template.setMessageConverter(jacksonJmsMessageConverter);
+        return template;
+    }
+    
     // The Qualifer annotation is added to indicate to Spring which specific bean needs to autowire
     @Bean
     public JmsListenerContainerFactory<?> jmsFactory(@Qualifier("jmsConnectionFactory") ConnectionFactory connectionFactory, DefaultJmsListenerContainerFactoryConfigurer configurer) {
@@ -37,6 +46,12 @@ public class ToDoConfig {
         configurer.configure(factory, connectionFactory);
         return factory;
     }
+    
+    @Bean
+    public ConnectionFactory jmsConnectionFactory() {
+        return new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+    }
+   
     
     @Configuration
     static class MethodListenerConfig implements JmsListenerConfigurer {
@@ -54,5 +69,6 @@ public class ToDoConfig {
         
         
     }
+   
     
 }

--- a/ch09/todo-jms/src/main/java/com/apress/todo/filter/ToDoMetricsFilter.java
+++ b/ch09/todo-jms/src/main/java/com/apress/todo/filter/ToDoMetricsFilter.java
@@ -1,0 +1,33 @@
+package com.apress.todo.filter;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+
+@Component
+public class ToDoMetricsFilter implements Filter {
+
+    private final MeterRegistry meterRegistry;
+
+    public ToDoMetricsFilter(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest req = (HttpServletRequest) request;
+
+        if ("GET".equals(req.getMethod()) && req.getRequestURI().equals("/toDos")) {
+            meterRegistry.counter("api_get_total").increment();
+        }
+        if ("POST".equals(req.getMethod()) && req.getRequestURI().equals("/toDos")) {
+            meterRegistry.counter("api_post_todos_total").increment();
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/ch09/todo-jms/src/main/resources/application.properties
+++ b/ch09/todo-jms/src/main/resources/application.properties
@@ -1,10 +1,14 @@
 spring.application.name=todo-jms
+todo.jms.destination=toDoDestination
 # JPA
 spring.jpa.generate-ddl=true
 spring.jpa.hibernate.ddl-auto=create-drop
-# ToDo JMS
-todo.jms.destination=toDoDestination
-#TODO Para evitar el error del esquema de transporte no reconocido, debes agregar la propiedad para la conexión de ActiveMQ
 spring.activemq.broker-url=vm://localhost
 spring.activemq.in-memory=true
 spring.activemq.packages.trust-all=true
+spring.artemis.mode=embedded
+management.endpoints.web.exposure.include=*
+management.endpoint.prometheus.enabled=true
+management.metrics.export.prometheus.enabled=true
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+


### PR DESCRIPTION
Hi @jerryperezperez,

ch09/todo-jms/pom.xml

1. Replaced    <artifactId>activemq-broker</artifactId> with <artifactId>artemis-jakarta-server</artifactId>

Spring Boot 3+ migrated fully to Jakarta EE, which uses jakarta.jms.* instead of javax.jms.*.

activemq-broker (ActiveMQ Classic) still depends on javax.jms.

This causes incompatibility, compile errors, or runtime ClassNotFoundException

 Added actuator and prometheus dependies
 2. Added ActiveMQBrokerConfig  to configure and initialize an embedded ActiveMQ broker

3. ch09/todo-jms/src/main/java/com/apress/todo/config/ToDoConfig.java
creates a JmsTemplate connected to your broker, using a JSON converter, so your app can send and receive Java objects via JMS easily

4. ch09\todo-jms\src\main\java\com\apress\todo\filter\ToDoMetricsFilter.java
ToDoMetricsFilter is a Servlet filter that counts GET and POST requests to /toDos, storing them in Micrometer counters so you can monitor API usage in Grafana.

Please review it.

Thank You.



